### PR TITLE
Fix category reference in element-uap10-extension.md

### DIFF
--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap10-extension.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap10-extension.md
@@ -53,7 +53,7 @@ Declares an extensibility point for the app.
 
 | Attribute | Description | Data type | Required | Default value |
 |-|-|-|-|-|
-| **Category** | The type of package extensibility point. | A string that can have one of the following values: *windows.posPaymentProvider*. | Yes |  |
+| **Category** | The type of package extensibility point. | A string that can have one of the following values: *windows.protocol*. | Yes |  |
 | **EntryPoint** | The activatable class ID. | A string with a value between 1 and 256 characters in length. Represents the task handling the extension (normally the fully namespace-qualified name of a Windows Runtime type). If EntryPoint is not specified, the EntryPoint defined for the app is used instead. | No |  |
 | **Executable** | The default launch executable. | A string with a value between 1 and 256 characters in length, that must end with `.exe`, and cannot contain these characters: `<`, `>`, `:`, `"`, `|`, `?`, or `*`. Specifies the default executable for the extension. If not specified, the executable defined for the app is used. If specified, the EntryPoint property is also used. If that EntryPoint property isn't specified, the EntryPoint defined for the app is used. | No |  |
 | **RuntimeType** | The runtime provider. Typically used when there are mixted frameworks in an app. | A string with a value between 1 and 255 characters in length that cannot start or end with a `.` or contain there characters: `<`, `>`, `:`, `"`, `|`, `?`, or `*`. | No |  |


### PR DESCRIPTION
uap10:Extension (Application) category is correctly documented as `windows.protocol` in the syntax section, but the Category row in the table references an incorrect category (probably copy/paste from uap8). Switch to the right category name.